### PR TITLE
Add Typescript support to Gatsby Config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,0 @@
-/** @type {import('gatsby').GatsbyConfig} */
-module.exports = {
-  siteMetadata: {
-    siteUrl: `https://www.yourdomain.tld`,
-  },
-  plugins: [],
-}

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,0 +1,10 @@
+import type { GatsbyConfig } from "gatsby"
+
+const config: GatsbyConfig = {
+  siteMetadata: {
+    siteUrl: `https://www.yourdomain.tld`,
+  },
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
This pull request contains simple changes to the Gasby config file to include Typescript documented in the [new Gatsby v4.9 release](https://www.gatsbyjs.com/docs/reference/release-notes/v4.9/#support-for-typescript-in-gatsby-config-and-gatsby-node).